### PR TITLE
🔥 Hotfix: Consent Screen Display Logic

### DIFF
--- a/app/src/main/kotlin/com/ngapp/metanmobile/MainActivityViewModel.kt
+++ b/app/src/main/kotlin/com/ngapp/metanmobile/MainActivityViewModel.kt
@@ -58,10 +58,7 @@ class MainActivityViewModel @Inject constructor(
     }
 
     private fun onObserveConsent() {
-        val isPrivacyOptionsRequired = consentHelper.isPrivacyOptionsRequired()
-        if (isPrivacyOptionsRequired) {
-            consentHelper.obtainConsentAndShow()
-        }
+        consentHelper.obtainConsentAndShow()
         viewModelScope.launch {
             consentHelper.canShowAds.collect { canShow ->
                 _consentState.value = _consentState.value.copy(canShowAds = canShow)

--- a/core/database/src/main/kotlin/com/ngapp/metanmobile/core/database/MetanMobileDatabase.kt
+++ b/core/database/src/main/kotlin/com/ngapp/metanmobile/core/database/MetanMobileDatabase.kt
@@ -50,7 +50,7 @@ import com.ngapp.metanmobile.core.database.util.ListStringConverter
         PriceResourceEntity::class,
         LocationResourceEntity::class,
     ],
-    version = 5,
+    version = 6,
     exportSchema = false,
 )
 @TypeConverters(

--- a/core/ui/src/main/kotlin/com/ngapp/metanmobile/core/ui/ads/ConsentHelper.kt
+++ b/core/ui/src/main/kotlin/com/ngapp/metanmobile/core/ui/ads/ConsentHelper.kt
@@ -78,7 +78,7 @@ class ConsentHelper {
 
         val ci = UserMessagingPlatform.getConsentInformation(context)
         ci.requestConsentInfoUpdate(context, params, {
-            if (showingForm) return@requestConsentInfoUpdate
+            if (isPrivacyOptionsRequired() && showingForm) return@requestConsentInfoUpdate
             showingForm = true
             UserMessagingPlatform.loadAndShowConsentFormIfRequired(context) { error ->
                 showingForm = false

--- a/feature/menu/legalregulations/privacypolicy/src/main/kotlin/com/ngapp/metanmobile/feature/privacypolicy/PrivacyPolicyScreen.kt
+++ b/feature/menu/legalregulations/privacypolicy/src/main/kotlin/com/ngapp/metanmobile/feature/privacypolicy/PrivacyPolicyScreen.kt
@@ -79,7 +79,7 @@ internal fun PrivacyPolicyRoute(
     viewModel: PrivacyPolicyViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
-    val isPrivacyOptionsRequired by viewModel.isPrivacyOptionsRequired
+    val isPrivacyOptionsRequired by viewModel.isPrivacyOptionsRequired.collectAsStateWithLifecycle()
 
     PrivacyPolicyScreen(
         modifier = modifier,

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ androidMinSdk = "21"
 androidTargetSdk = "34"
 versionMajor = "2"
 versionMinor = "1"
-versionPatch = "1"
+versionPatch = "2"
 applicationId = "com.ngapp.metanmobile"
 
 accompanist = "0.34.0"


### PR DESCRIPTION
## Summary

This PR addresses an issue in the obtainConsentAndShow() function, ensuring the consent screen is shown only to users in applicable regions (e.g., EEA) and suppressing it elsewhere.

## Changes Made

	1.	Updated Logic: The obtainConsentAndShow() function was modified to check whether the consent screen is required based on the user’s location and privacy requirement status.
	2.	Refactoring: Integrated the isPrivacyOptionsRequired() method within obtainConsentAndShow() to streamline the logic and prevent unnecessary consent prompts for users outside designated regions.

## Potential Risks

	•	Geolocation Accuracy: Potential risk if geolocation does not reliably identify regions.
	•	Ad Availability: Ensure ad initialization is not affected by changes in consent flow.

## Testing

	•	Steps:
	•	Tested on various devices simulating different regions (EEA and non-EEA).
	•	Verified that the consent screen appears only in regions requiring user consent.
	•	Environment:
	•	Devices: Pixel 8 Pro 
	•	App Version: 2.1.2

## Checklist

	•	Code follows project guidelines.
	•	No failing tests related to this feature.
	•	Self-review completed.
	•	Relevant reviewers added.

## Additional Information

None