### PR TITLE
🔥 Hotfix: allowBackup="false"

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -34,7 +34,7 @@
 
     <application
         android:name="com.ngapp.metanmobile.MetanMobileApplication"
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:enableOnBackInvokedCallback="true"
         android:hardwareAccelerated="true"
         android:icon="@mipmap/ic_launcher_round"

--- a/app/src/main/kotlin/com/ngapp/metanmobile/MainActivityViewModel.kt
+++ b/app/src/main/kotlin/com/ngapp/metanmobile/MainActivityViewModel.kt
@@ -30,6 +30,9 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted.Companion.WhileSubscribed
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.flatMapConcat
+import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
@@ -58,9 +61,15 @@ class MainActivityViewModel @Inject constructor(
     }
 
     private fun onObserveConsent() {
-        consentHelper.obtainConsentAndShow()
         viewModelScope.launch {
-            consentHelper.canShowAds.collect { canShow ->
+            userDataRepository.userData.collectLatest { userData ->
+                if (userData.shouldHideOnboarding) {
+                    consentHelper.obtainConsentAndShow()
+                }
+            }
+        }
+        viewModelScope.launch {
+            consentHelper.canShowAds.collectLatest { canShow ->
                 _consentState.value = _consentState.value.copy(canShowAds = canShow)
             }
         }

--- a/app/src/main/kotlin/com/ngapp/metanmobile/navigation/MMNavHost.kt
+++ b/app/src/main/kotlin/com/ngapp/metanmobile/navigation/MMNavHost.kt
@@ -53,6 +53,7 @@ import com.ngapp.metanmobile.feature.stations.list.navigation.stationsScreen
 import com.ngapp.metanmobile.feature.termsandconditions.navigation.navigateToTermsAndConditions
 import com.ngapp.metanmobile.feature.termsandconditions.navigation.termsAndConditionsScreen
 import com.ngapp.metanmobile.ui.MMAppState
+import kotlin.reflect.KClass
 
 /**
  * Top-level navigation graph. Navigation is organized as explained at
@@ -66,11 +67,12 @@ fun MMNavHost(
     appState: MMAppState,
     onShowSnackbar: suspend (String, String?) -> Boolean,
     modifier: Modifier = Modifier,
+    startDestination: KClass<*>,
 ) {
     val navController = appState.navController
     NavHost(
         navController = navController,
-        startDestination = OnboardingScreenNavigation::class,
+        startDestination = startDestination,
         modifier = modifier,
     ) {
         onboardingScreen(onSkipOnboarding = appState::navigateFromOnboardingToHomeScreen)

--- a/app/src/main/kotlin/com/ngapp/metanmobile/ui/MMApp.kt
+++ b/app/src/main/kotlin/com/ngapp/metanmobile/ui/MMApp.kt
@@ -66,6 +66,7 @@ import com.ngapp.metanmobile.core.designsystem.component.MetanMobileGradientBack
 import com.ngapp.metanmobile.core.designsystem.theme.Green
 import com.ngapp.metanmobile.core.designsystem.theme.LocalGradientColors
 import com.ngapp.metanmobile.core.ui.ads.MainBannerAd
+import com.ngapp.metanmobile.feature.onboarding.navigation.OnboardingScreenNavigation
 import com.ngapp.metanmobile.navigation.MMNavHost
 import kotlin.reflect.KClass
 import com.ngapp.metanmobile.core.ui.R as CoreUiR
@@ -73,6 +74,7 @@ import com.ngapp.metanmobile.core.ui.R as CoreUiR
 @Composable
 fun MMApp(
     appState: MMAppState,
+    startDestination: KClass<*>,
     modifier: Modifier = Modifier,
     windowAdaptiveInfo: WindowAdaptiveInfo = currentWindowAdaptiveInfo(),
     viewModel: MainActivityViewModel = hiltViewModel(),
@@ -95,6 +97,7 @@ fun MMApp(
 
             MMApp(
                 appState = appState,
+                startDestination = startDestination,
                 snackbarHostState = snackbarHostState,
                 consentState = consentState,
                 windowAdaptiveInfo = windowAdaptiveInfo,
@@ -106,6 +109,7 @@ fun MMApp(
 @Composable
 internal fun MMApp(
     appState: MMAppState,
+    startDestination: KClass<*>,
     snackbarHostState: SnackbarHostState,
     consentState: ConsentState,
     modifier: Modifier = Modifier,
@@ -151,10 +155,10 @@ internal fun MMApp(
                 }
             }
         ) {
-            DestinationScaffold(appState, snackbarHostState, modifier)
+            DestinationScaffold(appState, startDestination, snackbarHostState, modifier)
         }
     } else {
-        DestinationScaffold(appState, snackbarHostState, modifier)
+        DestinationScaffold(appState, startDestination, snackbarHostState, modifier)
     }
 }
 
@@ -162,6 +166,7 @@ internal fun MMApp(
 @Composable
 private fun DestinationScaffold(
     appState: MMAppState,
+    startDestination: KClass<*>,
     snackbarHostState: SnackbarHostState,
     modifier: Modifier = Modifier,
 ) {
@@ -193,6 +198,7 @@ private fun DestinationScaffold(
                             duration = Short,
                         ) == ActionPerformed
                     },
+                    startDestination = startDestination,
                 )
             }
         }

--- a/core/data/src/main/kotlin/com/ngapp/metanmobile/core/data/repository/station/OfflineFirstStationsRepository.kt
+++ b/core/data/src/main/kotlin/com/ngapp/metanmobile/core/data/repository/station/OfflineFirstStationsRepository.kt
@@ -62,7 +62,7 @@ class OfflineFirstStationsRepository @Inject constructor(
             .map(StationResourceEntity::asExternalModel)
 
     override suspend fun syncWith(synchronizer: Synchronizer): Boolean {
-        return synchronizer.updateDataSync<NetworkStationResource>(
+        return synchronizer.updateDataSync(
             dataFetcher = { parser.getStations(true) },
             dataWriter = { networkStationList ->
                 val newData = networkStationList.map(NetworkStationResource::asEntity)

--- a/core/database/src/main/kotlin/com/ngapp/metanmobile/core/database/MetanMobileDatabase.kt
+++ b/core/database/src/main/kotlin/com/ngapp/metanmobile/core/database/MetanMobileDatabase.kt
@@ -50,7 +50,7 @@ import com.ngapp.metanmobile.core.database.util.ListStringConverter
         PriceResourceEntity::class,
         LocationResourceEntity::class,
     ],
-    version = 6,
+    version = 8,
     exportSchema = false,
 )
 @TypeConverters(

--- a/core/database/src/main/kotlin/com/ngapp/metanmobile/core/database/dao/station/StationResourceDao.kt
+++ b/core/database/src/main/kotlin/com/ngapp/metanmobile/core/database/dao/station/StationResourceDao.kt
@@ -56,7 +56,6 @@ interface StationResourceDao {
                 END)
             ORDER BY 
             CASE
-                WHEN :sortingType = 'DISTANCE' THEN distance_between 
                 WHEN :sortingType = 'STATION_NAME' THEN title 
                 ELSE NULL 
             END
@@ -93,7 +92,6 @@ interface StationResourceDao {
                 END)
             ORDER BY 
             CASE
-                WHEN :sortingType = 'DISTANCE' THEN distance_between 
                 WHEN :sortingType = 'STATION_NAME' THEN title 
                 ELSE NULL 
             END

--- a/core/database/src/main/kotlin/com/ngapp/metanmobile/core/database/model/station/StationResourceEntity.kt
+++ b/core/database/src/main/kotlin/com/ngapp/metanmobile/core/database/model/station/StationResourceEntity.kt
@@ -40,7 +40,6 @@ data class StationResourceEntity(
     val payment: String,
     val latitude: String,
     val longitude: String,
-    @ColumnInfo(name = "distance_between") val distanceBetween: Double = 0.0,
     @ColumnInfo(name = "busy_on_monday") val busyOnMonday: String,
     @ColumnInfo(name = "busy_on_tuesday") val busyOnTuesday: String,
     @ColumnInfo(name = "busy_on_wednesday") val busyOnWednesday: String,

--- a/core/model/src/main/kotlin/com/ngapp/metanmobile/core/model/location/LocationResource.kt
+++ b/core/model/src/main/kotlin/com/ngapp/metanmobile/core/model/location/LocationResource.kt
@@ -29,8 +29,8 @@ data class LocationResource(
         fun init() = LocationResource(
             id = 1,
             time = System.now().toEpochMilliseconds(),
-            latitude = 0.0,
-            longitude = 0.0
+            latitude = 53.90309661691656,
+            longitude = 27.55363993274304,
         )
     }
 }

--- a/core/network/src/main/kotlin/com/ngapp/metanmobile/core/network/network/MetanMobileParser.kt
+++ b/core/network/src/main/kotlin/com/ngapp/metanmobile/core/network/network/MetanMobileParser.kt
@@ -17,7 +17,6 @@
 
 package com.ngapp.metanmobile.core.network.network
 
-import android.util.Log
 import com.ngapp.metanmobile.core.network.BuildConfig
 import com.ngapp.metanmobile.core.network.MetanMobileParserDataSource
 import com.ngapp.metanmobile.core.network.di.NetworkModule
@@ -59,7 +58,8 @@ class MetanMobileParser @Inject constructor(
     override suspend fun getStations(isRefreshing: Boolean): List<NetworkStationResource> {
         val currentParser = if (isRefreshing) parserNoCache else parser
         val channel = currentParser.getChannel(urlStations)
-        return channel.articles.map { it.asNetworkStationResource() }
+        val response = channel.articles
+        return response.map { it.asNetworkStationResource() }
     }
 
     override suspend fun getStation(

--- a/gradle.properties
+++ b/gradle.properties
@@ -56,3 +56,4 @@ kotlin.code.style=official
 # https://developer.android.com/build/releases/gradle-plugin#default-changes
 android.defaults.buildfeatures.resvalues=false
 android.defaults.buildfeatures.shaders=false
+ksp.incremental=false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ androidMinSdk = "21"
 androidTargetSdk = "34"
 versionMajor = "2"
 versionMinor = "1"
-versionPatch = "2"
+versionPatch = "5"
 applicationId = "com.ngapp.metanmobile"
 
 accompanist = "0.34.0"


### PR DESCRIPTION
## Summary

This PR disables Allow Backup to prevent unexpected restoration of DataStore data across installs.

## Changes Made

	1.	Set android:allowBackup to false in the manifest to prevent data from being backed up or restored.

Potential Risks

	•	Data Loss on Reinstall: Users will no longer have their DataStore data restored on reinstall, which may affect user experience for those expecting persistent data.

## Testing

	•	Environment:
	•	Devices: Pixel 8 Pro
	•	App Version: 2.1.3
	•	Steps:
	•	Tested fresh installs to confirm DataStore data is not restored.

## Checklist

	•	Code follows project guidelines.
	•	Self-review completed.
	•	Relevant reviewers added.

## Additional Information

None